### PR TITLE
add upgrade operation

### DIFF
--- a/checks/imperative-management.nix
+++ b/checks/imperative-management.nix
@@ -75,4 +75,22 @@ lib.optionalAttrs stdenv.isLinux {
       """)
     '';
   };
+
+  remove_dummy = mkTest {
+    name = "miniguest-remove-dummy";
+    testScript = ''
+      machine.succeed("""
+        miniguest install /tmp/flake1#dummy
+      """)
+      machine.succeed("""
+        miniguest remove dummy
+      """)
+      machine.succeed("""
+        test ! -e /etc/miniguests/nonexistent
+      """)
+      machine.succeed("""
+        test ! -e /nix/var/nix/miniguest-profiles/nonexistent
+      """)
+    '';
+  };
 }

--- a/miniguest/install.bash
+++ b/miniguest/install.bash
@@ -21,5 +21,8 @@ parse_flake_reference "$_arg_flake_reference"
 
 mkdir -p "$guests_dir" || die "" $?
 mkdir -p "$profiles_dir" || die "" $?
-run_nix build --profile "$profiles_dir/$guest_name" "$flake#nixosConfigurations.$guest_name.config.system.build.miniguest" || die "unable to build guest!" $?
-ln -sf "$profiles_dir/$guest_name" "$guests_dir" || die "" $?
+
+reset_profile "$guest_name" # FIXME: need an atomic reset-and-install
+install_profile "$guest_name" "$flake#nixosConfigurations.$guest_name.config.system.build.miniguest"
+
+have_control_of_symlink "$guest_name" && ln -sf "$profiles_dir/$guest_name" "$guests_dir"

--- a/miniguest/main.bash
+++ b/miniguest/main.bash
@@ -25,6 +25,14 @@ nix="$_arg_nix"
 
 source functions.bash
 
-if test "${_arg_command:?}" = install; then
+case "${_arg_command:?}" in
+install)
 	source install.bash "${_arg_leftovers[@]}"
-fi
+	;;
+upgrade)
+	source upgrade.bash "${_arg_leftovers[@]}"
+	;;
+remove)
+	source remove.bash "${_arg_leftovers[@]}"
+	;;
+esac

--- a/miniguest/main_arg.bash
+++ b/miniguest/main_arg.bash
@@ -16,7 +16,7 @@
 # along with Miniguest.  If not, see <https://www.gnu.org/licenses/>.
 
 # ARG_POSITIONAL_SINGLE(command, subcommand to run)
-# ARG_TYPE_GROUP_SET(commands, COMMAND, command, [install,help])
+# ARG_TYPE_GROUP_SET(commands, COMMAND, command, [install,upgrade,remove,help])
 # ARG_OPTIONAL_SINGLE(guests-dir, , directory containing guests profiles, /etc/miniguests)
 # ARG_OPTIONAL_SINGLE(nix, , path to the nix binary, @nixFlakes@/bin/nix)
 # ARG_LEFTOVERS(subcommand arguments)

--- a/miniguest/remove.bash
+++ b/miniguest/remove.bash
@@ -1,0 +1,7 @@
+source remove_arg.bash
+
+guest_name="$_arg_guest_name"
+
+reset_profile "$guest_name"
+
+have_control_of_symlink "$guest_name" && rm -f "$guests_dir/$guest_name"

--- a/miniguest/remove_arg.bash
+++ b/miniguest/remove_arg.bash
@@ -1,0 +1,2 @@
+# ARG_POSITIONAL_SINGLE(guest-name, name of guest to remove)
+# ARGBASH_GO

--- a/miniguest/upgrade.bash
+++ b/miniguest/upgrade.bash
@@ -1,0 +1,5 @@
+source upgrade_arg.bash
+
+guest_name="$_arg_guest_name"
+
+upgrade_profile "$guest_name"

--- a/miniguest/upgrade_arg.bash
+++ b/miniguest/upgrade_arg.bash
@@ -1,0 +1,2 @@
+# ARG_POSITIONAL_SINGLE(guest-name, name of guest to upgrade)
+# ARGBASH_GO


### PR DESCRIPTION
Leverage nix profiles to allow a miniguest to follow the original flake.

I would like something similar to `nix-env -ri` in install just to be sure but idk how to do it atomically.