### PR TITLE
add a lxc proper image

### DIFF
--- a/miniguest/lxc-template.nix
+++ b/miniguest/lxc-template.nix
@@ -1,0 +1,16 @@
+{ runCommand, fakeroot }:
+
+runCommand "miniguest-lxc-template" { nativeBuildInputs = [ fakeroot ]; } ''
+  cat >config << EOF
+  lxc.include = LXC_TEMPLATE_CONFIG/common.conf
+
+  lxc.mount.entry = /nix/store nix/store none ro,bind,create=dir 0 0
+  lxc.mount.entry = /etc/miniguests/LXC_NAME/boot boot none ro,bind,create=dir 0 0
+  lxc.init.cmd = /boot/init
+  EOF
+  mkdir -p rootfs/{nix/store,boot}
+
+  mkdir -p $out
+  fakeroot tar cJf $out/rootfs.tar.xz -C rootfs .
+  fakeroot tar cJf $out/meta.tar.xz config
+''

--- a/miniguest/overlay.nix
+++ b/miniguest/overlay.nix
@@ -1,3 +1,4 @@
 final: prev: {
+  miniguest-lxc-template = final.callPackage ./lxc-template.nix { };
   miniguest = final.callPackage ./package.nix { };
 }

--- a/miniguest/package.nix
+++ b/miniguest/package.nix
@@ -12,12 +12,12 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-{ lib, stdenv, argbash, bash, nixFlakes, shellcheck, makeWrapper }:
+{ lib, stdenv, argbash, bash, miniguest-lxc-template, nixFlakes, shellcheck, makeWrapper }:
 
 stdenv.mkDerivation {
   name = "miniguest";
   src = ./.;
-  inherit bash nixFlakes;
+  inherit bash miniguest-lxc-template nixFlakes;
 
   nativeBuildInputs = [ argbash makeWrapper ];
 


### PR DESCRIPTION
for lxc-create. should ideally work with `-t none`