### PR TITLE
enforce pure PATH

### DIFF
--- a/checks/imperative-management.nix
+++ b/checks/imperative-management.nix
@@ -28,7 +28,10 @@ let
   mkTest = { name, testScript }: nixosTest {
     inherit name;
     machine = {
-      environment.systemPackages = [ miniguest ];
+      environment.systemPackages = [
+        # wrapper clears PATH to check for implicit dependencies
+        (writeShellScriptBin "miniguest" ''PATH= exec ${miniguest}/bin/miniguest "$@"'')
+      ];
       environment.etc."pinned-nixpkgs".source = pinned-nixpkgs;
       system.extraDependencies = [ (import pinned-nixpkgs { inherit system; }).stdenvNoCC ];
       virtualisation.memorySize = 1024;

--- a/miniguest/package.nix
+++ b/miniguest/package.nix
@@ -12,7 +12,7 @@
 # ACTION OF CONTRACT, NEGLIGENCE OR OTHER TORTIOUS ACTION, ARISING OUT OF
 # OR IN CONNECTION WITH THE USE OR PERFORMANCE OF THIS SOFTWARE.
 
-{ lib, stdenv, argbash, bash, nixFlakes, shellcheck, makeWrapper }:
+{ lib, stdenv, argbash, bash, coreutils, nixFlakes, shellcheck, makeWrapper }:
 
 stdenv.mkDerivation {
   name = "miniguest";
@@ -34,8 +34,9 @@ stdenv.mkDerivation {
     mkdir -p $out/{libexec/miniguest,bin}
       mv *.bash $out/libexec/miniguest
       chmod +x $out/libexec/miniguest/main.bash
+      # keep PATH open ended since Nix pulls from the environment e.g. git
       makeWrapper $out/libexec/miniguest/main.bash $out/bin/miniguest \
-        --prefix PATH ":" "$out/libexec/miniguest"
+        --prefix PATH ":" "$out/libexec/miniguest:${coreutils}/bin"
   '';
 
   doInstallCheck = true;


### PR DESCRIPTION
Good practice in the Nix ecosystem.
Missing:
- mercurial
- something else?