### PR TITLE
declarative: avoid deprecated `nixpkgs.initialSystem`

### DIFF
--- a/declarative/default.nix
+++ b/declarative/default.nix
@@ -37,7 +37,7 @@ with lib;
               specifies the nix platform type for which the guest should be built.
             '';
             type = types.str;
-            default = config.nixpkgs.initialSystem;
+            default = config.nixpkgs.system;
             defaultText = literalDocBook "same as the host";
           };
         };


### PR DESCRIPTION
###### Motivation for this change
Fix #32

###### Things done

<!-- Please check what applies. Note that these are not hard requirements, especially if they dont seem to be applicable. -->

- Built on platform(s)
  - [x] NixOS
  - [ ] other Linux
- [x] `nix flake check` succeeds
- [ ] Tested intended functionality manually
- [ ] Documented intended functionality
- [x] Added checks for intended functionality
- [x] Changed Nix files are formatted per `nixpkgs-fmt`
- [ ] Changed Bash files are formatted per `shfmt`
