### PR TITLE
address evaluation warnings

### DIFF
--- a/checks/declarative-management.nix
+++ b/checks/declarative-management.nix
@@ -16,11 +16,17 @@ let
             fsType = "tmpfs";
             options = [ "defaults" "mode=755" ];
           };
+
+          system.stateVersion = "22.05";
         };
         miniguests.container.configuration = {
           boot.miniguest.enable = true;
           boot.miniguest.guestType = "lxc";
+
+          system.stateVersion = "22.05";
         };
+
+        system.stateVersion = "22.05";
       }
     ];
   };
@@ -39,19 +45,25 @@ let
             fsType = "tmpfs";
             options = [ "defaults" "mode=755" ];
           };
+
+          system.stateVersion = "22.05";
         };
         miniguests.container.system = "i686-linux";
         miniguests.container.configuration = {
           boot.miniguest.enable = true;
           boot.miniguest.guestType = "lxc";
+
+          system.stateVersion = "22.05";
         };
+        system.stateVersion = "22.05";
       }
     ];
   };
 in
 with nixpkgs.legacyPackages.${system};
-optionalAttrs stdenv.isLinux {
-  build_declarative_host = declarative_host.config.system.build.toplevel;
-} // optionalAttrs (stdenv.isLinux && stdenv.isx86_64) {
+optionalAttrs stdenv.isLinux
+  {
+    build_declarative_host = declarative_host.config.system.build.toplevel;
+  } // optionalAttrs (stdenv.isLinux && stdenv.isx86_64) {
   build_declarative_host_cross = declarative_host.config.system.build.toplevel;
 }

--- a/checks/imperative-management.nix
+++ b/checks/imperative-management.nix
@@ -27,7 +27,7 @@ let
 
   mkTest = { name, testScript }: nixosTest {
     inherit name;
-    machine = {
+    nodes.machine = {
       environment.systemPackages = [
         # wrapper clears PATH to check for implicit dependencies
         (writeShellScriptBin "miniguest" ''PATH= exec ${miniguest}/bin/miniguest "$@"'')

--- a/checks/simple-guests.nix
+++ b/checks/simple-guests.nix
@@ -27,6 +27,8 @@ let
           fsType = "tmpfs";
           options = [ "defaults" "mode=755" ];
         };
+
+        system.stateVersion = "22.05";
       }
     ];
   };
@@ -37,6 +39,8 @@ let
       {
         boot.miniguest.enable = true;
         boot.miniguest.guestType = "lxc";
+
+        system.stateVersion = "22.05";
       }
     ];
   };

--- a/checks/templates.nix
+++ b/checks/templates.nix
@@ -7,7 +7,7 @@ in
 lib.optionalAttrs stdenv.isLinux {
   create_container = nixosTest {
     name = "miniguest-create-container";
-    machine = {
+    nodes.machine = {
       imports = [ self.nixosModules.declarative ];
 
       virtualisation.lxc.enable = true;


### PR DESCRIPTION
###### Motivation for this change
`system.stateVersion` is becoming required. NixOS tests tell you to change `machine` to `nodes.machine`
###### Things done

<!-- Please check what applies. Note that these are not hard requirements, especially if they dont seem to be applicable. -->

- Built on platform(s)
  - [x] NixOS
  - [ ] other Linux
- [x] `nix flake check` succeeds
- [ ] Tested intended functionality manually
- [ ] Documented intended functionality
- [x] Added checks for intended functionality
- [x] Changed Nix files are formatted per `nixpkgs-fmt`
- [ ] Changed Bash files are formatted per `shfmt`
