### PR TITLE
core/qemu: add virtiofs support

### DIFF
--- a/checks/declarative-management.nix
+++ b/checks/declarative-management.nix
@@ -19,6 +19,18 @@ let
 
           system.stateVersion = "22.05";
         };
+        miniguests.virtual-machine-with-virtio.configuration = {
+          boot.miniguest.enable = true;
+          boot.miniguest.qemu.fsType = "virtiofs";
+
+          fileSystems."/" = {
+            device = "none";
+            fsType = "tmpfs";
+            options = [ "defaults" "mode=755" ];
+          };
+
+          system.stateVersion = "22.05";
+        };
         miniguests.container.configuration = {
           boot.miniguest.enable = true;
           boot.miniguest.guestType = "lxc";
@@ -37,8 +49,22 @@ let
       self.nixosModules.declarative
       {
         boot.isContainer = true;
+        miniguests.virtual-machine.system = "i686-linux";
         miniguests.virtual-machine.configuration = {
           boot.miniguest.enable = true;
+
+          fileSystems."/" = {
+            device = "none";
+            fsType = "tmpfs";
+            options = [ "defaults" "mode=755" ];
+          };
+
+          system.stateVersion = "22.05";
+        };
+        miniguests.virtual-machine-with-virtio.system = "i686-linux";
+        miniguests.virtual-machine-with-virtio.configuration = {
+          boot.miniguest.enable = true;
+          boot.miniguest.qemu.fsType = "virtiofs";
 
           fileSystems."/" = {
             device = "none";

--- a/core/default.nix
+++ b/core/default.nix
@@ -24,6 +24,11 @@ with lib;
         default = "qemu";
         type = types.enum [ "qemu" "lxc" ];
       };
+      qemu.fsType = mkOption {
+        description = "Which shared file system to use to mount the host store";
+        default = "9p";
+        type = types.enum [ "9p" "virtiofs" ];
+      };
     };
   };
 

--- a/core/internal/qemu-glue.nix
+++ b/core/internal/qemu-glue.nix
@@ -1,4 +1,4 @@
-# Copyright 2021 Louis Bettens
+# Copyright 2022 Louis Bettens
 # 
 # Permission to use, copy, modify, and/or distribute this software for any
 # purpose with or without fee is hereby granted, provided that the above
@@ -23,16 +23,19 @@ in
 mkIf (cfg.enable && cfg.guestType == "qemu") {
   fileSystems."/boot" = {
     device = "boot";
-    fsType = "9p";
+    inherit (cfg.qemu) fsType;
     neededForBoot = true;
   };
 
   fileSystems."/nix/store" = {
     device = "nix-store";
-    fsType = "9p";
+    inherit (cfg.qemu) fsType;
   };
 
-  boot.initrd.availableKernelModules = [ "virtio_pci" "9p" "9pnet_virtio" ];
+  boot.initrd.availableKernelModules = getAttr cfg.qemu.fsType {
+    "9p" = [ "virtio_pci" "9p" "9pnet_virtio" ];
+    virtiofs = [ "virtio_pci" "virtiofs" ];
+  };
 
   boot.initrd.postMountCommands = ''
     test "$stage2Init" = /init && stage2Init=/boot/init


### PR DESCRIPTION
###### Motivation for this change
Close #39 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements, especially if they dont seem to be applicable. -->

- Built on platform(s)
  - [x] NixOS
  - [ ] other Linux
- [x] `nix flake check` succeeds
- [x] Tested intended functionality manually
- [ ] Documented intended functionality
- [x] Added checks for intended functionality
- [x] Changed Nix files are formatted per `nixpkgs-fmt`
- [x] Changed Bash files are formatted per `shfmt`
