### PR TITLE
tool: guest name defaults to hostname

### DIFF
--- a/core/default.nix
+++ b/core/default.nix
@@ -19,6 +19,11 @@ with lib;
   options = {
     boot.miniguest = {
       enable = mkEnableOption "turn this configuration into a miniguest guest system.";
+      guestName = mkOption {
+        description = "What name to install this guest under.";
+        default = null;
+        type = with types; nullOr str;
+      };
       guestType = mkOption {
         description = "Which hypervisor technology this guest should be configured for.";
         default = "qemu";

--- a/tool/install.cpp
+++ b/tool/install.cpp
@@ -73,6 +73,15 @@ struct CmdInstall : virtual InstallableCommand, virtual MixProfile {
   void run(ref<Store> store) override {
     auto evalState = getEvalState();
 
+    if (!guest_name) {
+      auto cursor = installable->getCursor(*evalState).get_ptr();
+      for (auto &a : {"config", "boot", "miniguest", "guestName"})
+        if (cursor)
+          cursor = cursor->maybeGetAttr(a);
+      if (cursor)
+        guest_name = cursor->getString();
+    }
+
     if (!guest_name)
       guest_name =
           evalState->symbols


### PR DESCRIPTION
###### Motivation for this change
Makes `nixConfigurations.default` more useful

###### Things done

<!-- Please check what applies. Note that these are not hard requirements, especially if they dont seem to be applicable. -->

- Built on platform(s)
  - [x] NixOS
  - [ ] other Linux
- [ ] `nix flake check` succeeds
- [ ] Tested intended functionality manually
- [ ] Documented intended functionality
- [ ] Added checks for intended functionality
- [x] Changed Nix files are formatted per `nixpkgs-fmt`
- [ ] ~~Changed Bash files are formatted per `shfmt`~~
