### PR TITLE
tool/create: take guest config into account

### DIFF
--- a/core/internal/build.nix
+++ b/core/internal/build.nix
@@ -26,6 +26,7 @@ mkIf cfg.enable {
       mkdir -p $out/boot
       ln -sT ${config.system.build.toplevel}/init $out/boot/init
       cp ${closureInfo}/registration $out/boot/nix-path-registration
+    ln -s ${pkgs.writeText "miniguest-config.json" (builtins.toJSON cfg)} $out/miniguest-config.json
     ${lib.optionalString (cfg.guestType == "qemu")
     "cp -P ${config.system.build.toplevel}/{kernel,initrd} -t $out"
     }

--- a/tool/common.hpp
+++ b/tool/common.hpp
@@ -17,6 +17,7 @@
  */
 
 #include <filesystem>
+#include <nlohmann/json.hpp>
 #include <optional>
 
 namespace miniguest {
@@ -47,5 +48,27 @@ private:
 };
 
 void completeGuestName(size_t, std::string_view prefix);
+
+enum class GuestType { qemu, lxc };
+NLOHMANN_JSON_SERIALIZE_ENUM(GuestType, {
+                                            {GuestType::qemu, "qemu"},
+                                            {GuestType::lxc, "lxc"},
+                                        })
+
+enum class QemuFsType { _9p, virtiofs };
+NLOHMANN_JSON_SERIALIZE_ENUM(QemuFsType, {
+                                             {QemuFsType::_9p, "9p"},
+                                             {QemuFsType::virtiofs, "virtiofs"},
+                                         })
+
+struct GuestConfig final {
+  GuestType guest_type;
+  QemuFsType qemu_fs_type;
+};
+
+inline void from_json(const nlohmann::json &j, GuestConfig &cfg) {
+  j.at("guestType").get_to(cfg.guest_type);
+  j.at("qemu").at("fsType").get_to(cfg.qemu_fs_type);
+}
 
 } // namespace miniguest


### PR DESCRIPTION
###### Motivation for this change
Improve results by saving the declared config and reading it when running `create`. 

###### Things done

<!-- Please check what applies. Note that these are not hard requirements, especially if they dont seem to be applicable. -->

- Built on platform(s)
  - [x] NixOS
  - [ ] other Linux
- [x] `nix flake check` succeeds
- [x] Tested intended functionality manually
- [ ] Documented intended functionality
- [ ] Added checks for intended functionality
- [x] Changed Nix files are formatted per `nixpkgs-fmt`
- [x] Changed C++ files are formatted per `clang-format`
